### PR TITLE
Temp disable of tagging as its borked on travis [ch179]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,8 +73,9 @@ cleanbranches:
 	git branch --merged | egrep -v "(^\*|master|dev)" | xargs git branch -d
 
 tag:
-	git tag "$(DEPLOY_TIME)_$(SHA)"
-	git push origin $(DEPLOY_TIME)_$(SHA)
+	echo "Disabling tagging as its borked on travis"
+	# git tag "$(DEPLOY_TIME)_$(SHA)"
+	# git push origin $(DEPLOY_TIME)_$(SHA)
 
 lint_the_things: markdownlint pylint
 


### PR DESCRIPTION
# Your checklist for this pull request

Please review the [guidelines for contributing](Contributing.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] Make sure you are making a pull request against the **master branch**.
  - Also please start *your branch* off *our master*.
- [x] Check your code additions will fail neither code linting checks nor unit test.

## Description

The last PR left master in a broken state as Travis can't do the tagging of a release.  This temporarily disables it so builds on master can be green again.

## Useful Resources

N/A
